### PR TITLE
Add inactivity nudge and improve engagement prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Product order capture with WhatsApp alerts to admin
 - MongoDB-based storage of chats, orders and appointments
 - Multilingual support
+- Automatic nudge if a user is inactive for over 20 hours
 
 ---
 

--- a/chat_engine.py
+++ b/chat_engine.py
@@ -66,10 +66,12 @@ Your tasks:
      - 14mg: ~~₹3,870~~ **₹3,096**  
      - Delivery: **₹399**
 
-   - **Mounjaro Tirzepatide**:  
-     - 2.5mg: ~~₹3,500~~ **₹2,800**  
-     - 5mg: ~~₹4,375~~ **₹3,500**  
+   - **Mounjaro Tirzepatide**:
+     - 2.5mg: ~~₹3,500~~ **₹2,800**
+     - 5mg: ~~₹4,375~~ **₹3,500**
      - Delivery: **₹2,500**
+
+   - *Frequency*: **Mounjaro injections are once weekly** while **Rybelsus tablets are taken daily**.
 
 7. Discount logic:
    - Start with sale price if mentioned  
@@ -92,11 +94,13 @@ Your tasks:
    *This is not medical advice. Always consult a licensed doctor for personal health concerns.*
 
 10. Format all questions/follow-ups using bullets. Keep tone:
-   - Warm  
-   - Human  
-   - Helpful  
-   - Short & clear  
+   - Warm
+   - Human
+   - Helpful
+   - Short & clear
    - Never robotic
+
+11. After each reply, invite the user to share more or ask any questions they have.
 """
 
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import asyncio
 from typing import Optional
 
 from fastapi import FastAPI
@@ -11,6 +12,7 @@ from dotenv import load_dotenv
 from routes import router
 
 from db import db
+from nudge import start_nudge_loop
 
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
@@ -35,6 +37,12 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok"}
 
 app.include_router(router)
+
+
+@app.on_event("startup")
+async def start_tasks() -> None:
+    """Launch background tasks on startup."""
+    asyncio.create_task(start_nudge_loop())
 
 
 if __name__ == "__main__":

--- a/nudge.py
+++ b/nudge.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+
+from db import db
+from utils import send_whatsapp_message
+
+logger = logging.getLogger(__name__)
+
+NUDGE_HOURS = int(os.getenv("NUDGE_HOURS", "20"))
+NUDGE_TEXT = os.getenv(
+    "NUDGE_TEXT",
+    "Hi! We noticed you haven't continued our chat. Complete your order today and get 5% off!",
+)
+
+
+async def check_and_nudge() -> None:
+    """Send a nudge message to inactive users."""
+    if db is None:
+        logger.debug("Database not configured; skipping nudge check")
+        return
+
+    cutoff = datetime.utcnow() - timedelta(hours=NUDGE_HOURS)
+    async for user in db.users.find({"chats": {"$ne": []}}):
+        last_chat = user.get("chats", [])[-1]
+        if not last_chat:
+            continue
+        try:
+            last_time = datetime.fromisoformat(last_chat.get("time"))
+        except Exception:
+            continue
+        last_nudge_time = user.get("last_nudge")
+        if last_nudge_time:
+            try:
+                last_nudge = datetime.fromisoformat(last_nudge_time)
+            except Exception:
+                last_nudge = None
+        else:
+            last_nudge = None
+        if last_time < cutoff and (not last_nudge or last_nudge < last_time):
+            phone = user.get("phone")
+            if phone:
+                name = user.get("name", "there")
+                text = f"Hi {name}! {NUDGE_TEXT}"
+                await send_whatsapp_message(phone, text)
+                await db.users.update_one(
+                    {"_id": user["_id"]},
+                    {"$set": {"last_nudge": datetime.utcnow().isoformat()}},
+                )
+                logger.info("Sent nudge to %s", phone)
+
+
+async def start_nudge_loop() -> None:
+    """Background loop to periodically nudge inactive users."""
+    while True:
+        try:
+            await check_and_nudge()
+        except Exception as exc:
+            logger.exception("Nudge check failed: %s", exc)
+        await asyncio.sleep(3600)
+


### PR DESCRIPTION
## Summary
- create background task to nudge inactive users after 20 hours
- start nudge service on FastAPI startup
- note weekly Mounjaro and daily Rybelsus dosing in the system prompt
- encourage questions in every reply via system prompt
- document new nudge feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6868e7df2ad483268cd4cdc5120c0039